### PR TITLE
Updates to Zipkin 2.16 by vendoring internal code previously borrowed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk11
 
 sudo: false # faster builds
 

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -50,7 +50,7 @@
                     <classifier>module</classifier>
                     <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
                     <excludeGroupIds>
-                        io.zipkin.zipkin2,org.springframework.boot,org.springframework,org.slf4j,com.fasterxml.jackson.core,com.google.auto.value,com.squareup.moshi,com.squareup.okio,com.squareup.okhttp3
+                        io.zipkin.zipkin2,org.springframework.boot,org.springframework,org.slf4j,com.fasterxml.jackson.core,com.google.auto.value
                     </excludeGroupIds>
                 </configuration>
                 <executions>

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -50,7 +50,7 @@
                     <classifier>module</classifier>
                     <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
                     <excludeGroupIds>
-                        io.zipkin.zipkin2,org.springframework.boot,org.springframework,org.slf4j,com.fasterxml.jackson.core,com.google.auto.value
+                        io.zipkin.zipkin2,org.springframework.boot,org.springframework,org.slf4j,com.fasterxml.jackson.core
                     </excludeGroupIds>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 
     <properties>
         <zipkin-logzio-version>0.0.4</zipkin-logzio-version>
-        <zipkin.version>2.14.2</zipkin.version>
         <!-- make sure this matches zipkin's version -->
-        <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+        <zipkin.version>2.16.0</zipkin.version>
+        <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
     </properties>
 
     <modules>

--- a/storage-logzio/pom.xml
+++ b/storage-logzio/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
+        <okhttp.version>3.14.2</okhttp.version>
     </properties>
 
     <dependencies>
@@ -22,24 +23,20 @@
             <artifactId>logzio-sender</artifactId>
             <version>1.1.0</version>
         </dependency>
-
         <dependency>
-            <groupId>io.zipkin.zipkin2</groupId>
-            <artifactId>zipkin-storage-elasticsearch</artifactId>
-            <version>${zipkin.version}</version>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
-        <!-- the following versions are taken from zipkin -->
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
             <version>1.17.4</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi</artifactId>
             <version>1.8.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -51,7 +48,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.12.2</version>
+            <version>3.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -63,7 +60,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>3.14.1</version>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/BodyConverters.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/BodyConverters.java
@@ -16,22 +16,16 @@ package zipkin2.storage.logzio;
 import com.squareup.moshi.JsonReader;
 import okio.BufferedSource;
 import zipkin2.Span;
-import zipkin2.elasticsearch.internal.client.HttpCall;
-import zipkin2.elasticsearch.internal.client.SearchResultConverter;
+import zipkin2.storage.logzio.client.HttpCall;
+import zipkin2.storage.logzio.client.SearchResultConverter;
 
 import java.io.IOException;
 import java.util.List;
+import zipkin2.storage.logzio.json.JsonAdapters;
 
-import static zipkin2.elasticsearch.internal.JsonReaders.collectValuesNamed;
+import static zipkin2.storage.logzio.json.JsonReaders.collectValuesNamed;
 
 public final class BodyConverters {
-    static final HttpCall.BodyConverter<Object> NULL =
-            new HttpCall.BodyConverter<Object>() {
-                @Override
-                public Object convert(BufferedSource content) {
-                    return null;
-                }
-            };
     static final HttpCall.BodyConverter<List<String>> KEYS =
             new HttpCall.BodyConverter<List<String>>() {
                 @Override

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/LogzioSpanStore.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/LogzioSpanStore.java
@@ -5,12 +5,12 @@ import org.slf4j.LoggerFactory;
 import zipkin2.Call;
 import zipkin2.DependencyLink;
 import zipkin2.Span;
-import zipkin2.elasticsearch.internal.client.HttpCall;
 import zipkin2.storage.GroupByTraceId;
 import zipkin2.storage.QueryRequest;
 import zipkin2.storage.SpanStore;
 import zipkin2.storage.StrictTraceId;
 import zipkin2.storage.logzio.client.Aggregation;
+import zipkin2.storage.logzio.client.HttpCall;
 import zipkin2.storage.logzio.client.SearchCallFactory;
 import zipkin2.storage.logzio.client.SearchRequest;
 

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/client/HttpCall.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/client/HttpCall.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.client;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.internal.http.HttpHeaders;
+import okio.BufferedSource;
+import okio.GzipSource;
+import okio.Okio;
+import zipkin2.Call;
+import zipkin2.Callback;
+
+public final class HttpCall<V> extends Call.Base<V> {
+
+  public interface BodyConverter<V> {
+    V convert(BufferedSource content) throws IOException;
+  }
+
+  public static class Factory implements Closeable {
+    final OkHttpClient ok;
+    final Semaphore semaphore;
+    public final HttpUrl baseUrl;
+
+    public Factory(OkHttpClient ok, HttpUrl baseUrl) {
+      this.ok = ok;
+      this.semaphore = new Semaphore(ok.dispatcher().getMaxRequests());
+      this.baseUrl = baseUrl;
+    }
+
+    public <V> HttpCall<V> newCall(Request request, BodyConverter<V> bodyConverter) {
+      return new HttpCall<>(this, request, bodyConverter);
+    }
+
+    @Override public void close() {
+      ok.dispatcher().executorService().shutdownNow();
+    }
+  }
+
+  public final okhttp3.Call call;
+  public final BodyConverter<V> bodyConverter;
+  final Semaphore semaphore;
+
+  HttpCall(Factory factory, Request request, BodyConverter<V> bodyConverter) {
+    this(
+      factory.ok.newCall(request),
+      factory.semaphore,
+      bodyConverter
+    );
+  }
+
+  HttpCall(okhttp3.Call call, Semaphore semaphore, BodyConverter<V> bodyConverter) {
+    this.call = call;
+    this.semaphore = semaphore;
+    this.bodyConverter = bodyConverter;
+  }
+
+  @Override protected V doExecute() throws IOException {
+    if (!semaphore.tryAcquire()) throw new IllegalStateException("over capacity");
+    try {
+      return parseResponse(call.execute(), bodyConverter);
+    } finally {
+      semaphore.release();
+    }
+  }
+
+  @Override protected void doEnqueue(Callback<V> callback) {
+    if (!semaphore.tryAcquire()) {
+      callback.onError(new IllegalStateException("over capacity"));
+      return;
+    }
+    call.enqueue(new V2CallbackAdapter<>(semaphore, bodyConverter, callback));
+  }
+
+  @Override protected void doCancel() {
+    call.cancel();
+  }
+
+  @Override public HttpCall<V> clone() {
+    return new HttpCall<V>(call.clone(), semaphore, bodyConverter);
+  }
+
+  @Override
+  public String toString() {
+    return "HttpCall(" + call + ")";
+  }
+
+  static class V2CallbackAdapter<V> implements okhttp3.Callback {
+    final Semaphore semaphore;
+    final BodyConverter<V> bodyConverter;
+    final Callback<V> delegate;
+
+    V2CallbackAdapter(Semaphore semaphore, BodyConverter<V> bodyConverter, Callback<V> delegate) {
+      this.semaphore = semaphore;
+      this.bodyConverter = bodyConverter;
+      this.delegate = delegate;
+    }
+
+    @Override public void onFailure(okhttp3.Call call, IOException e) {
+      semaphore.release();
+      delegate.onError(e);
+    }
+
+    /** Note: this runs on the {@link okhttp3.OkHttpClient#dispatcher() dispatcher} thread! */
+    @Override public void onResponse(okhttp3.Call call, Response response) {
+      semaphore.release();
+      try {
+        delegate.onSuccess(parseResponse(response, bodyConverter));
+      } catch (Throwable e) {
+        propagateIfFatal(e);
+        delegate.onError(e);
+      }
+    }
+  }
+
+  public static <V> V parseResponse(Response response, BodyConverter<V> bodyConverter)
+    throws IOException {
+    if (!HttpHeaders.hasBody(response)) {
+      if (response.isSuccessful()) {
+        return null;
+      } else {
+        throw new IllegalStateException("response failed: " + response);
+      }
+    }
+    try (ResponseBody responseBody = response.body()) {
+      BufferedSource content = responseBody.source();
+      if ("gzip".equalsIgnoreCase(response.header("Content-Encoding"))) {
+        content = Okio.buffer(new GzipSource(responseBody.source()));
+      }
+      if (response.isSuccessful()) {
+        return bodyConverter.convert(content);
+      } else {
+        throw new IllegalStateException(
+          "response for " + response.request().tag() + " failed: " + content.readUtf8());
+      }
+    }
+  }
+}

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchCallFactory.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchCallFactory.java
@@ -19,16 +19,15 @@ import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import zipkin2.elasticsearch.internal.client.HttpCall;
 import zipkin2.internal.Nullable;
 
 public class SearchCallFactory {
     private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
     public static final String API_TOKEN_HEADER = "X-API-TOKEN";
 
-    private final HttpCall.Factory http;
-    private final String apiToken;
-    private final JsonAdapter<SearchRequest> searchRequest =
+    final HttpCall.Factory http;
+    final String apiToken;
+    final JsonAdapter<SearchRequest> searchRequest =
             new Moshi.Builder().build().adapter(SearchRequest.class);
 
     public SearchCallFactory(HttpCall.Factory http, String apiToken) {
@@ -46,10 +45,9 @@ public class SearchCallFactory {
         return http.newCall(httpRequest, bodyConverter);
     }
 
-    private HttpUrl lenientSearch(@Nullable String type) {
+    HttpUrl lenientSearch(@Nullable String type) {
         HttpUrl.Builder builder = http.baseUrl.newBuilder();
         if (type != null) builder.addPathSegment(type);
         return builder.build();
     }
-
 }

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchCallFactory.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchCallFactory.java
@@ -25,9 +25,9 @@ public class SearchCallFactory {
     private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
     public static final String API_TOKEN_HEADER = "X-API-TOKEN";
 
-    final HttpCall.Factory http;
-    final String apiToken;
-    final JsonAdapter<SearchRequest> searchRequest =
+    private final HttpCall.Factory http;
+    private final String apiToken;
+    private final JsonAdapter<SearchRequest> searchRequest =
             new Moshi.Builder().build().adapter(SearchRequest.class);
 
     public SearchCallFactory(HttpCall.Factory http, String apiToken) {
@@ -45,7 +45,7 @@ public class SearchCallFactory {
         return http.newCall(httpRequest, bodyConverter);
     }
 
-    HttpUrl lenientSearch(@Nullable String type) {
+    private HttpUrl lenientSearch(@Nullable String type) {
         HttpUrl.Builder builder = http.baseUrl.newBuilder();
         if (type != null) builder.addPathSegment(type);
         return builder.build();

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchResultConverter.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/client/SearchResultConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.client;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import okio.BufferedSource;
+
+import static zipkin2.storage.logzio.json.JsonReaders.enterPath;
+
+public class SearchResultConverter<T> implements HttpCall.BodyConverter<List<T>> {
+  final JsonAdapter<T> adapter;
+  final List<T> defaultValue;
+
+  public static <T> SearchResultConverter<T> create(JsonAdapter<T> adapter) {
+    return new SearchResultConverter<>(adapter);
+  }
+
+  protected SearchResultConverter(JsonAdapter<T> adapter) {
+    this.adapter = adapter;
+    this.defaultValue = Collections.emptyList();
+  }
+
+  @Override public List<T> convert(BufferedSource content) throws IOException {
+    JsonReader hits = enterPath(JsonReader.of(content), "hits", "hits");
+    if (hits == null || hits.peek() != JsonReader.Token.BEGIN_ARRAY) return defaultValue;
+
+    List<T> result = new ArrayList<>();
+    hits.beginArray();
+    while (hits.hasNext()) {
+      JsonReader source = enterPath(hits, "_source");
+      if (source != null) {
+        result.add(adapter.fromJson(source));
+      }
+      hits.endObject();
+    }
+    hits.endArray();
+    return result.isEmpty() ? defaultValue : result;
+  }
+}

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/json/JsonAdapters.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/json/JsonAdapters.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin2.storage.logzio;
+package zipkin2.storage.logzio.json;
 
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
@@ -28,8 +28,8 @@ import java.io.IOException;
  * Read-only json adapters resurrected from before we switched to Java 6 as storage components can
  * be Java 7+
  */
-final class JsonAdapters {
-    static final JsonAdapter<Span> SPAN_ADAPTER =
+public final class JsonAdapters {
+    public static final JsonAdapter<Span> SPAN_ADAPTER =
             new JsonAdapter<Span>() {
                 @Override
                 public Span fromJson(JsonReader reader) throws IOException {

--- a/storage-logzio/src/main/java/zipkin2/storage/logzio/json/JsonReaders.java
+++ b/storage-logzio/src/main/java/zipkin2/storage/logzio/json/JsonReaders.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.json;
+
+import com.squareup.moshi.JsonReader;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import zipkin2.internal.Nullable;
+
+public final class JsonReaders {
+
+  /**
+   * This saves you from having to define nested types to read a single value
+   *
+   * <p>Instead of defining two types like this, and double-checking null..
+   *
+   * <pre>{@code
+   * class Response {
+   *   Message message;
+   * }
+   * class Message {
+   *   String status;
+   * }
+   * JsonAdapter<Response> adapter = moshi.adapter(Response.class);
+   * Message message = adapter.fromJson(body.source());
+   * if (message != null && message.status != null) throw new IllegalStateException(message.status);
+   * }</pre>
+   *
+   * <p>You can advance to the field directly.
+   *
+   * <pre>{@code
+   * JsonReader status = enterPath(JsonReader.of(body.source()), "message", "status");
+   * if (status != null) throw new IllegalStateException(status.nextString());
+   * }</pre>
+   */
+  @Nullable
+  public static JsonReader enterPath(JsonReader reader, String path1, String path2)
+      throws IOException {
+    return enterPath(reader, path1) != null ? enterPath(reader, path2) : null;
+  }
+
+  @Nullable
+  public static JsonReader enterPath(JsonReader reader, String path) throws IOException {
+    try {
+      if (reader.peek() != JsonReader.Token.BEGIN_OBJECT) return null;
+    } catch (EOFException e) {
+      return null;
+    }
+    reader.beginObject();
+    while (reader.hasNext()) {
+      if (reader.nextName().equals(path) && reader.peek() != JsonReader.Token.NULL) {
+        return reader;
+      } else {
+        reader.skipValue();
+      }
+    }
+    reader.endObject();
+    return null;
+  }
+
+  public static List<String> collectValuesNamed(JsonReader reader, String name) throws IOException {
+    Set<String> result = new LinkedHashSet<>();
+    visitObject(reader, name, result);
+    return new ArrayList<>(result);
+  }
+
+  static void visitObject(JsonReader reader, String name, Set<String> result) throws IOException {
+    reader.beginObject();
+    while (reader.hasNext()) {
+      if (reader.nextName().equals(name)) {
+        result.add(reader.nextString());
+      } else {
+        visitNextOrSkip(reader, name, result);
+      }
+    }
+    reader.endObject();
+  }
+
+  static void visitNextOrSkip(JsonReader reader, String name, Set<String> result)
+      throws IOException {
+    switch (reader.peek()) {
+      case BEGIN_ARRAY:
+        reader.beginArray();
+        while (reader.hasNext()) visitObject(reader, name, result);
+        reader.endArray();
+        break;
+      case BEGIN_OBJECT:
+        visitObject(reader, name, result);
+        break;
+      default:
+        reader.skipValue();
+    }
+  }
+
+  JsonReaders() {}
+}

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/LogzioSpanConsumerTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/LogzioSpanConsumerTest.java
@@ -1,3 +1,5 @@
+package zipkin2.storage.logzio;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -9,10 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Endpoint;
 import zipkin2.Span;
-import zipkin2.storage.logzio.ConsumerParams;
-import zipkin2.storage.logzio.LogzioSpanConsumer;
-import zipkin2.storage.logzio.LogzioStorage;
-import zipkin2.storage.logzio.LogzioStorageParams;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/LogzioSpanStoreTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/LogzioSpanStoreTest.java
@@ -1,3 +1,5 @@
+package zipkin2.storage.logzio;
+
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -8,11 +10,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.Span;
-import zipkin2.elasticsearch.internal.client.HttpCall;
-import zipkin2.storage.logzio.BodyConverters;
-import zipkin2.storage.logzio.LogzioSpanStore;
-import zipkin2.storage.logzio.LogzioStorage;
-import zipkin2.storage.logzio.LogzioStorageParams;
+import zipkin2.storage.logzio.client.HttpCall;
 import zipkin2.storage.logzio.client.SearchCallFactory;
 import zipkin2.storage.logzio.client.SearchRequest;
 

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/client/HttpCallTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/client/HttpCallTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.client;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin2.Call;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class HttpCallTest {
+  @Rule
+  public MockWebServer mws = new MockWebServer();
+
+  HttpCall.Factory http = new HttpCall.Factory(new OkHttpClient(), mws.url(""));
+  Request request = new Request.Builder().url(http.baseUrl).build();
+
+  @After
+  public void close() {
+    http.close();
+  }
+
+  @Test
+  public void executionException_conversionException() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    Call<?> call = http.newCall(request, b -> {
+      throw new IllegalArgumentException("eeek");
+    });
+
+    try {
+      call.execute();
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void cloned() throws Exception {
+    mws.enqueue(new MockResponse());
+
+    Call<?> call = http.newCall(request, b -> null);
+    call.execute();
+
+    try {
+      call.execute();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException expected) {
+      assertThat(expected).isInstanceOf(IllegalStateException.class);
+    }
+
+    mws.enqueue(new MockResponse());
+
+    call.clone().execute();
+  }
+
+  @Test
+  public void executionException_httpFailure() throws Exception {
+    mws.enqueue(new MockResponse().setResponseCode(500));
+
+    Call<?> call = http.newCall(request, b -> null);
+
+    try {
+      call.execute();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException expected) {
+      assertThat(expected).isInstanceOf(IllegalStateException.class);
+    }
+  }
+}

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/client/SearchRequestTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/client/SearchRequestTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.client;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchRequestTest {
+  SearchRequest request = SearchRequest.create("foo");
+  JsonAdapter<SearchRequest> adapter = new Moshi.Builder().build().adapter(SearchRequest.class);
+
+  @Test
+  public void defaultSizeIsMaxResultWindow() {
+    assertThat(request).extracting("size")
+        .isEqualTo(10000);
+  }
+
+  /** Indices and type affect the request URI, not the json body */
+  @Test
+  public void doesntSerializeIndicesOrType() {
+    assertThat(adapter.toJson(request))
+        .isEqualTo("{\"size\":10000}");
+  }
+}

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/json/JsonAdaptersTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/json/JsonAdaptersTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.json;
+
+import java.io.IOException;
+import okio.Buffer;
+import org.junit.Test;
+import zipkin2.DependencyLink;
+import zipkin2.Endpoint;
+import zipkin2.codec.DependencyLinkBytesEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.storage.logzio.json.JsonAdapters.SPAN_ADAPTER;
+
+public class JsonAdaptersTest {
+  @Test
+  public void span_ignoreNull_parentId() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"parentId\": null\n"
+            + "}";
+
+    SPAN_ADAPTER.fromJson(new Buffer().writeUtf8(json));
+  }
+
+  @Test
+  public void span_ignoreNull_timestamp() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"timestamp\": null\n"
+            + "}";
+
+    SPAN_ADAPTER.fromJson(new Buffer().writeUtf8(json));
+  }
+
+  @Test
+  public void span_ignoreNull_duration() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"duration\": null\n"
+            + "}";
+
+    SPAN_ADAPTER.fromJson(new Buffer().writeUtf8(json));
+  }
+
+  @Test
+  public void span_ignoreNull_debug() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"debug\": null\n"
+            + "}";
+
+    SPAN_ADAPTER.fromJson(new Buffer().writeUtf8(json));
+  }
+
+  @Test
+  public void span_ignoreNull_annotation_endpoint() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"annotations\": [\n"
+            + "    {\n"
+            + "      \"timestamp\": 1461750491274000,\n"
+            + "      \"value\": \"cs\",\n"
+            + "      \"endpoint\": null\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    SPAN_ADAPTER.fromJson(new Buffer().writeUtf8(json));
+  }
+
+  @Test
+  public void span_endpointHighPort() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"localEndpoint\": {\n"
+            + "    \"serviceName\": \"service\",\n"
+            + "    \"port\": 65535\n"
+            + "  }\n"
+            + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+        .isEqualTo(Endpoint.newBuilder().serviceName("service").port(65535).build());
+  }
+
+  @Test
+  public void span_noServiceName() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"localEndpoint\": {\n"
+            + "    \"port\": 65535\n"
+            + "  }\n"
+            + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+        .isEqualTo(Endpoint.newBuilder().serviceName("").port(65535).build());
+  }
+
+  @Test
+  public void span_nullServiceName() throws IOException {
+    String json =
+        "{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\",\n"
+            + "  \"localEndpoint\": {\n"
+            + "    \"serviceName\": NULL,\n"
+            + "    \"port\": 65535\n"
+            + "  }\n"
+            + "}";
+
+    assertThat(SPAN_ADAPTER.fromJson(json).localEndpoint())
+        .isEqualTo(Endpoint.newBuilder().serviceName("").port(65535).build());
+  }
+
+  @Test
+  public void span_readsTraceIdHighFromTraceIdField() throws IOException {
+    String with128BitTraceId =
+        ("{\n"
+            + "  \"traceId\": \"48485a3953bb61246b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\"\n"
+            + "}");
+    String withLower64bitsTraceId =
+        ("{\n"
+            + "  \"traceId\": \"6b221d5bc9e6496c\",\n"
+            + "  \"name\": \"get-traces\",\n"
+            + "  \"id\": \"6b221d5bc9e6496c\"\n"
+            + "}");
+
+    assertThat(SPAN_ADAPTER.fromJson(with128BitTraceId))
+        .isEqualTo(
+            SPAN_ADAPTER
+                .fromJson(withLower64bitsTraceId)
+                .toBuilder()
+                .traceId("48485a3953bb61246b221d5bc9e6496c")
+                .build());
+  }
+
+  @Test
+  public void dependencyLinkRoundTrip() throws IOException {
+    DependencyLink link =
+        DependencyLink.newBuilder().parent("foo").child("bar").callCount(2).build();
+
+    Buffer bytes = new Buffer();
+    bytes.write(DependencyLinkBytesEncoder.JSON_V1.encode(link));
+    assertThat(JsonAdapters.DEPENDENCY_LINK_ADAPTER.fromJson(bytes)).isEqualTo(link);
+  }
+
+  @Test
+  public void dependencyLinkRoundTrip_withError() throws IOException {
+    DependencyLink link =
+        DependencyLink.newBuilder().parent("foo").child("bar").callCount(2).errorCount(1).build();
+
+    Buffer bytes = new Buffer();
+    bytes.write(DependencyLinkBytesEncoder.JSON_V1.encode(link));
+    assertThat(JsonAdapters.DEPENDENCY_LINK_ADAPTER.fromJson(bytes)).isEqualTo(link);
+  }
+}

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/json/JsonReadersTest.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/json/JsonReadersTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.json;
+
+import com.squareup.moshi.JsonReader;
+import java.io.IOException;
+import java.util.List;
+import okio.Buffer;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonReadersTest {
+
+  @Test
+  public void enterPath_nested() throws IOException {
+    assertThat(
+            JsonReaders.enterPath(
+                    JsonReader.of(
+                        new Buffer()
+                            .writeUtf8(
+                                "{\n"
+                                    + "  \"name\" : \"Kamal\",\n"
+                                    + "  \"cluster_name\" : \"elasticsearch\",\n"
+                                    + "  \"version\" : {\n"
+                                    + "    \"number\" : \"2.4.0\",\n"
+                                    + "    \"build_hash\" : \"ce9f0c7394dee074091dd1bc4e9469251181fc55\",\n"
+                                    + "    \"build_timestamp\" : \"2016-08-29T09:14:17Z\",\n"
+                                    + "    \"build_snapshot\" : false,\n"
+                                    + "    \"lucene_version\" : \"5.5.2\"\n"
+                                    + "  },\n"
+                                    + "  \"tagline\" : \"You Know, for Search\"\n"
+                                    + "}")),
+                    "version",
+                    "number")
+                .nextString())
+        .isEqualTo("2.4.0");
+  }
+
+  @Test
+  public void enterPath_nullOnNoInput() throws IOException {
+    assertThat(JsonReaders.enterPath(JsonReader.of(new Buffer()), "message")).isNull();
+  }
+
+  @Test
+  public void collectValuesNamed_emptyWhenNotFound() throws IOException {
+    List<String> result =
+        JsonReaders.collectValuesNamed(
+            JsonReader.of(
+                new Buffer()
+                    .writeUtf8(
+                        "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0},\"hits\":{\"total\":0,\"max_score\":0.0,\"hits\":[]}}")),
+            "key");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void collectValuesNamed_mergesArrays() throws IOException {
+    List<String> result =
+        JsonReaders.collectValuesNamed(
+            JsonReader.of(new Buffer().writeUtf8(TestResponses.SPAN_NAMES)), "key");
+
+    assertThat(result).containsExactly("methodcall", "yak");
+  }
+
+  @Test
+  public void collectValuesNamed_mergesChildren() throws IOException {
+    List<String> result =
+        JsonReaders.collectValuesNamed(
+            JsonReader.of(new Buffer().writeUtf8(TestResponses.SERVICE_NAMES)), "key");
+
+    assertThat(result).containsExactly("yak", "service");
+  }
+
+  @Test
+  public void collectValuesNamed_nested() throws IOException {
+    List<String> result =
+        JsonReaders.collectValuesNamed(
+            JsonReader.of(
+                new Buffer()
+                    .writeUtf8(
+                        "{\n"
+                            + "  \"took\": 49,\n"
+                            + "  \"timed_out\": false,\n"
+                            + "  \"_shards\": {\n"
+                            + "    \"total\": 5,\n"
+                            + "    \"successful\": 5,\n"
+                            + "    \"failed\": 0\n"
+                            + "  },\n"
+                            + "  \"hits\": {\n"
+                            + "    \"total\": 1,\n"
+                            + "    \"max_score\": 0,\n"
+                            + "    \"hits\": []\n"
+                            + "  },\n"
+                            + "  \"aggregations\": {\n"
+                            + "    \"traceId_agg\": {\n"
+                            + "      \"doc_count_error_upper_bound\": 0,\n"
+                            + "      \"sum_other_doc_count\": 0,\n"
+                            + "      \"buckets\": [\n"
+                            + "        {\n"
+                            + "          \"key\": \"000000000000007b\",\n"
+                            + "          \"doc_count\": 1,\n"
+                            + "          \"timestamps_agg\": {\n"
+                            + "            \"value\": 1474761600001,\n"
+                            + "            \"value_as_string\": \"1474761600001\"\n"
+                            + "          }\n"
+                            + "        }\n"
+                            + "      ]\n"
+                            + "    }\n"
+                            + "  }\n"
+                            + "}")),
+            "key");
+
+    assertThat(result).containsExactly("000000000000007b");
+  }
+}

--- a/storage-logzio/src/test/java/zipkin2/storage/logzio/json/TestResponses.java
+++ b/storage-logzio/src/test/java/zipkin2/storage/logzio/json/TestResponses.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.logzio.json;
+
+final class TestResponses {
+  static final String SERVICE_NAMES =
+      "{\n"
+          + "  \"took\": 4,\n"
+          + "  \"timed_out\": false,\n"
+          + "  \"_shards\": {\n"
+          + "    \"total\": 5,\n"
+          + "    \"successful\": 5,\n"
+          + "    \"failed\": 0\n"
+          + "  },\n"
+          + "  \"hits\": {\n"
+          + "    \"total\": 1,\n"
+          + "    \"max_score\": 0,\n"
+          + "    \"hits\": []\n"
+          + "  },\n"
+          + "  \"aggregations\": {\n"
+          + "    \"binaryAnnotations_agg\": {\n"
+          + "      \"doc_count\": 1,\n"
+          + "      \"binaryAnnotationsServiceName_agg\": {\n"
+          + "        \"doc_count_error_upper_bound\": 0,\n"
+          + "        \"sum_other_doc_count\": 0,\n"
+          + "        \"buckets\": [\n"
+          + "          {\n"
+          + "            \"key\": \"yak\",\n"
+          + "            \"doc_count\": 1\n"
+          + "          }\n"
+          + "        ]\n"
+          + "      }\n"
+          + "    },\n"
+          + "    \"annotations_agg\": {\n"
+          + "      \"doc_count\": 2,\n"
+          + "      \"annotationsServiceName_agg\": {\n"
+          + "        \"doc_count_error_upper_bound\": 0,\n"
+          + "        \"sum_other_doc_count\": 0,\n"
+          + "        \"buckets\": [\n"
+          + "          {\n"
+          + "            \"key\": \"service\",\n"
+          + "            \"doc_count\": 2\n"
+          + "          }\n"
+          + "        ]\n"
+          + "      }\n"
+          + "    }\n"
+          + "  }\n"
+          + "}";
+
+  static final String SPAN_NAMES =
+      "{\n"
+          + "  \"took\": 1,\n"
+          + "  \"timed_out\": false,\n"
+          + "  \"_shards\": {\n"
+          + "    \"total\": 5,\n"
+          + "    \"successful\": 5,\n"
+          + "    \"failed\": 0\n"
+          + "  },\n"
+          + "  \"hits\": {\n"
+          + "    \"total\": 2,\n"
+          + "    \"max_score\": 0,\n"
+          + "    \"hits\": []\n"
+          + "  },\n"
+          + "  \"aggregations\": {\n"
+          + "    \"name_agg\": {\n"
+          + "      \"doc_count_error_upper_bound\": 0,\n"
+          + "      \"sum_other_doc_count\": 0,\n"
+          + "      \"buckets\": [\n"
+          + "        {\n"
+          + "          \"key\": \"methodcall\",\n"
+          + "          \"doc_count\": 1\n"
+          + "        },\n"
+          + "        {\n"
+          + "          \"key\": \"yak\",\n"
+          + "          \"doc_count\": 1\n"
+          + "        }\n"
+          + "      ]\n"
+          + "    }\n"
+          + "  }\n"
+          + "}";
+}


### PR DESCRIPTION
Before, this module used some internal types relating to okhttp client,
used in elasticsearch. This copies in the code as it is no-longer used
in Zipkin. This also copies in tests that pass from the last version in
Zipkin.

What happened was Zipkin changed to use the netty-based Armeria client,
so these okhttp types will no longer be maintained.