### PR TITLE
upgraded junit, jackson databind, spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <zipkin-logzio-version>0.0.5</zipkin-logzio-version>
+        <zipkin-logzio-version>0.0.6</zipkin-logzio-version>
         <!-- make sure this matches zipkin's version -->
-        <zipkin.version>2.16.0</zipkin.version>
-        <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
+        <zipkin.version>2.23.16</zipkin.version>
+        <spring-boot.version>2.4.13</spring-boot.version>
     </properties>
 
     <modules>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.13.2.1</version>
         </dependency>
 
         <dependency>

--- a/storage-logzio/pom.xml
+++ b/storage-logzio/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Spring boot upgrade does not include the latest spring4shell fix.